### PR TITLE
use raw string for regex to avoid misinterpreted escape characters

### DIFF
--- a/gdb-svd.py
+++ b/gdb-svd.py
@@ -242,7 +242,7 @@ class GdbSvdCmd(gdb.Command):
         if register.access in [None, "read-only", "read-write", "read-writeOnce"]:
             addr = peripheral.base_address + register.address_offset
             cmd = self.read_cmd.format(address=addr)
-            pattern = re.compile('(?P<ADDR>\w+):( *?(?P<VALUE>[a-f0-9]+))')
+            pattern = re.compile(r'(?P<ADDR>\w+):( *?(?P<VALUE>[a-f0-9]+))')
 
             try:
                 match = re.search(pattern, gdb.execute(cmd, False, True))


### PR DESCRIPTION
On recent distributions and recent GDB binary, sourcing the script causes this:
```
(gdb) source .gdbscripts/svd-tools/gdb-svd.py
.gdbscripts/svd-tools/gdb-svd.py:245: SyntaxWarning: invalid escape sequence '\w'
  pattern = re.compile('(?P<ADDR>\w+):( *?(?P<VALUE>[a-f0-9]+))')
  ```

Using a raw string prevent from interpreting the escape characters, and backslashes.

**Python version:**
```
$ python --version
Python 3.12.3
```

**GDB version:**
```
$ gdb-multiarch --version
GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

**OS:**
```
uname -a
Linux $HOSTNAME 6.8.0-101-generic #101-Ubuntu SMP PREEMPT_DYNAMIC Mon Feb  9 10:15:05 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
```